### PR TITLE
Changed methods, and functionality

### DIFF
--- a/browser/iframe-browser.js
+++ b/browser/iframe-browser.js
@@ -73,7 +73,6 @@ define(function (require, exports, module) {
     function update(url) {
         // If url has been sent, make the iFrames' src that of the url
         if(url) {
-            //iframeConfig.src = url;
             var $iframe = $("#bramble-iframe-browser");
             if ( $iframe.length ) {
                 $iframe.attr('src',url);

--- a/browser/iframe-browser.js
+++ b/browser/iframe-browser.js
@@ -10,21 +10,31 @@ define(function (require, exports, module) {
     // by default we use vertical orientation
     var _orientation = VERTICAL_ORIENTATION;
 
+
     /*
-     * Publicly avaialble function used to create an iframe within the second-panel
-     * url: Takes one argument of a url to a blob for the _update() function to use 
-     *      - if undefined we will not fill the iframe with an src
+     * Publicly avaialble function used to create an empty iframe within the second-panel
      */
-    function browse(url) {
+    function init() {
         //Get current GUI layout
         var result = MainViewManager.getLayoutScheme();
 
         // If iframe does not exist, then show it
         if(result.rows === 1 && result.columns === 1) {
-            _show(_orientation);
+            show(_orientation);
         }
-        // Call function that is used to create the iframe and fill it with url
-        _update(url);
+        /*
+         *Creating the empty iFrame we'll be using
+         * Starting by Emptying all contents of #second-pane
+         */
+        var _panel = $("#second-pane").empty();
+
+        // Create the iFrame for the blob to live in later
+        var iframeConfig = {
+            id: "bramble-iframe-browser",
+            frameborder: 0
+        };
+        //Append iFrame to _panel
+        $("<iframe>", iframeConfig).css({"width":"100%", "height":"100%"}).appendTo(_panel);
     }
 
     /*
@@ -60,23 +70,15 @@ define(function (require, exports, module) {
      * In which our iFrame will exists and will be filled
      * with the url that has been passed to this function
      */
-    function _update(url) {
-        // Empty all contents of #second-pane
-        var _panel = $("#second-pane").empty();
-
-        // Create the iFrame for the blob to live in
-        var iframeConfig = {
-            id: "bramble-iframe-browser",
-            frameborder: 0
-        };
-
+    function update(url) {
         // If url has been sent, make the iFrames' src that of the url
         if(url) {
-            iframeConfig.src = url;
+            //iframeConfig.src = url;
+            var $iframe = $("#bramble-iframe-browser");
+            if ( $iframe.length ) {
+                $iframe.attr('src',url);
+            }
         }
-
-        //Append iFrame to _panel
-        $("<iframe>", iframeConfig).css({"width":"100%", "height":"100%"}).appendTo(_panel);
     }
 
     // Return reference to iframe element or null if not available.
@@ -85,7 +87,8 @@ define(function (require, exports, module) {
     }
 
     // Define public API
-    exports.browse = browse;
+    exports.init = init;
+    exports.update = update;
     exports.show = show;
     exports.getBrowserIFrame = getBrowserIFrame;
     // Expose these constants on our module, so callers can use them with setOrientation()

--- a/browser/iframe-browser.js
+++ b/browser/iframe-browser.js
@@ -75,13 +75,9 @@ define(function (require, exports, module) {
      * with the url that has been passed to this function
      */
     function update(url) {
-        // If url has been sent, make the iFrames' src that of the url
         if(url) {
-            //Get the iframe
             var iframe = getBrowserIFrame();
-            //Check to make sure it exists
             if(iframe) {
-                //Set its src as url
                 iframe.src = url;
             }
         }

--- a/browser/iframe-browser.js
+++ b/browser/iframe-browser.js
@@ -15,6 +15,10 @@ define(function (require, exports, module) {
      * Publicly avaialble function used to create an empty iframe within the second-panel
      */
     function init() {
+        //Check to see if we've created the iframe already, return if so
+        if(getBrowserIFrame()) {
+            return;
+        }
         //Get current GUI layout
         var result = MainViewManager.getLayoutScheme();
 
@@ -73,9 +77,12 @@ define(function (require, exports, module) {
     function update(url) {
         // If url has been sent, make the iFrames' src that of the url
         if(url) {
-            var $iframe = $("#bramble-iframe-browser");
-            if ( $iframe.length ) {
-                $iframe.attr('src',url);
+            //Get the iframe
+            var iframe = getBrowserIFrame();
+            //Check to make sure it exists
+            if(iframe) {
+                //Set its src as url
+                iframe.src = url;
             }
         }
     }


### PR DESCRIPTION
I changed browse to init
init now intializes the iframe as an empty iframe, and thats all it does, no longer takes in url
update is now available as a public API and it takes in a url, and replaces the src of the iframe we create with it
