### PR TITLE
Fix HTML rewriter to include the html tag when parsing

### DIFF
--- a/nohost/src/rewriter.js
+++ b/nohost/src/rewriter.js
@@ -260,7 +260,7 @@ define(function (require, exports, module) {
             iterator("elements", 'audio', 'src', null),
         ], function finishedRewriteSeries(err, result) {
             // Return the processed HTML
-            var html = rewriter.doc.documentElement.innerHTML;
+            var html = rewriter.doc.documentElement.outerHTML;
             callback(err, html);
         });
     }


### PR DESCRIPTION
When running brackets we found that when the iframe for Live preview initially loads, the `<html>` element in it does not contain the `data-brackets-id` attribute that Brackets assigns it.

By digging into it a bit, I found that the problem is with the way that the Rewriter parses the html Document object. we only store the contents of the `<html>` tag and not the tag itself and this results in the loss of the `data-brackets-id` attribute. Somehow magically the iframe generated the `<html>` element possibly so that it could render it. But that should not happen and this fixes that issue.
