### PR TITLE
fixes humphd/brackets#120 - Create LiveDev StaticServer for non-HTML files

### DIFF
--- a/nohost/src/StaticServer.js
+++ b/nohost/src/StaticServer.js
@@ -1,0 +1,36 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
+/*global define, brackets */
+define(function (require, exports, module) {
+    "use strict";
+
+    var BaseServer              = brackets.getModule("LiveDevelopment/Servers/BaseServer").BaseServer,
+        BlobUtils               = brackets.getModule("filesystem/impls/filer/BlobUtils"),
+        Filer                   = brackets.getModule("filesystem/impls/filer/BracketsFiler");
+
+    function StaticServer(config) {
+        config = config || {};
+        BaseServer.call(this, config);
+    }
+
+    StaticServer.prototype = Object.create(BaseServer.prototype);
+    StaticServer.prototype.constructor = StaticServer;
+
+    //Returns a pre-generated blob url based on path
+    StaticServer.prototype.pathToUrl = function(path) {
+        return BlobUtils.getUrl(path);
+    };
+    //Returns a path based on blob url
+    StaticServer.prototype.urlToPath = function(url) {
+        return BlobUtils.getFilename(url);
+    };
+
+    StaticServer.prototype.start = function() {
+        this.fs = Filer.fs();
+    };
+
+    StaticServer.prototype.stop = function() {
+        this.fs = null;
+    };
+
+    exports.StaticServer = StaticServer;
+});


### PR DESCRIPTION
WIP. Patch for  [humphd/brackets#120](https://github.com/humphd/brackets/issues/120). The NewStaticServer is based on the one used by Brackets. This could be called by main.js like this: _staticServer = new NewStaticServer();
