### PR TITLE
Fix# humphd/brackets#108 Changed Font changer method

### DIFF
--- a/main.js
+++ b/main.js
@@ -112,7 +112,7 @@ define(function (require, exports, module) {
      * undo, redo, size changer, or any other buttons relating to menu or view
      * within event we expect to receive a JSONable object that contains a commandCategory:
      * menuCommand: "Menu Command" relating to menu commands runable
-     * viewCommand: "View Command" relating to functions in viewcommand
+     * fontChange: refers to a method we use to change fonts size
      * editorCommand: "Editor Command" relating to functions relating ot the editor itself
      * also contains a variable of "params" which can be used to send further information needed
      */
@@ -128,8 +128,18 @@ define(function (require, exports, module) {
             codeMirror.focus();
             CommandManager.execute(Commands[msgObj.command]);
         }
-        else if (msgObj.commandCategory === "viewCommand") {
-            ViewCommand[msgObj.command](msgObj.params);
+        else if (msgObj.commandCategory === "fontChange") {
+            CommandManager.execute(Commands[msgObj.Command]);
+            if(msgObj.params < "12") {
+                for(var i = 12; i > msgObj.params; i--) {
+                    CommandManager.execute(Commands["VIEW_DECREASE_FONT_SIZE"]);
+                }
+            }
+            else if(msgObj.params > "12") {
+                for(var i = 12; i < msgObj.params; i++) {
+                    CommandManager.execute(Commands["VIEW_INCREASE_FONT_SIZE"]);
+                }
+            }
         }
         else if (msgObj.commandCategory === "editorCommand") {
             Editor[msgObj.command](msgObj.params);


### PR DESCRIPTION
Changed method in which we change brackets font in order to be safer.

Basically theres 3 commands in the Menu, restore font(back to 12px), increase font(by 1 px), and decrease font(by 1 px).

Small is 10px, medium is 12px, and large is 18px

This is how it works:
1. Restore font back to 12px
2. With the font size sent from thimble, I use a for loop to run increase/decrease enough times to satisfy the size thimble requested

With this, we aren't directly interfacing with the ViewHandler and merely increasing the font in a natural way, thus it should not break anything
