### PR TITLE
update PostMessageTransport to work with two servers

### DIFF
--- a/lib/PostMessageTransport.js
+++ b/lib/PostMessageTransport.js
@@ -8,8 +8,13 @@ define(function (require, exports, module) {
 
     var _iframeRef,
         connId = 1;
+
+    var Launcher = require("./launcher");
     
-    var EventDispatcher = brackets.getModule("utils/EventDispatcher");
+    var EventDispatcher     = brackets.getModule("utils/EventDispatcher"),
+        LiveDevMultiBrowser = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser"),
+        BlobUtils           = brackets.getModule("filesystem/impls/filer/BlobUtils"),
+        Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path;
     
     // The script that will be injected into the previewed HTML to handle the other side of the post message connection.
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
@@ -51,14 +56,45 @@ define(function (require, exports, module) {
     }
 
     /**
+    * Replaces paths of linked files with blob urls
+    */
+    function resolveLinks(message) {
+        var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
+        if(!currentDoc) {
+            return message;
+        }
+
+        var currentDir = Path.dirname(currentDoc.doc.file.fullPath);
+        var linkRegex = new RegExp('\\"(href|src)\\":\\"([^"]+)\\"', 'gm');
+        var resolvedMessage = message.replace(linkRegex, function(match, attr, path) {
+            path = BlobUtils.getUrl(path.charAt(0) === "/" ? path : Path.join(currentDir, path));
+
+            return ["\"", attr, "\":\"", path, "\""].join("");
+        });
+
+        return resolvedMessage;
+    }
+
+    /**
      * Sends a transport-layer message via post message.
      * @param {number|Array.<number>} idOrArray A client ID or array of client IDs to send the message to.
      * @param {string} msgStr The message to send as a JSON string.
      */
     function send(idOrArray, msgStr){
         var win = _iframeRef.contentWindow;
+        var msg = JSON.parse(msgStr);
+
+        if(msg && msg.params && msg.params.expression) {
+            msg.params.expression = resolveLinks(msg.params.expression);
+        }
+
+        msgStr = JSON.stringify(msg);
 
         win.postMessage(msgStr,"*");
+
+        if(msg.method === "Page.reload" || msg.method === "Page.navigate") {
+            reload();
+        }
     }
 
     /**
@@ -76,6 +112,14 @@ define(function (require, exports, module) {
         return "<script>\n" +
             PostMessageTransportRemote +
             "</script>\n";
+    }
+
+    function reload() {
+        var launcher = Launcher.getCurrentInstance();
+        var liveDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
+        var url = BlobUtils.getUrl(liveDoc.doc.file.fullPath);
+
+        launcher.launch(url);
     }
     
     // Exports


### PR DESCRIPTION
This patch intercepts messages being sent by the transport and reloads the live preview and/or inserts correct blob URL for CSS documents.
