### PR TITLE
Random fixes

### DIFF
--- a/lib/PostMessageTransport.js
+++ b/lib/PostMessageTransport.js
@@ -10,17 +10,17 @@ define(function (require, exports, module) {
         connId = 1;
 
     var Launcher = require("./launcher");
-    
+
     var EventDispatcher     = brackets.getModule("utils/EventDispatcher"),
         LiveDevMultiBrowser = brackets.getModule("LiveDevelopment/LiveDevMultiBrowser"),
         BlobUtils           = brackets.getModule("filesystem/impls/filer/BlobUtils"),
         Path                = brackets.getModule("filesystem/impls/filer/BracketsFiler").Path;
-    
+
     // The script that will be injected into the previewed HTML to handle the other side of the post message connection.
     var PostMessageTransportRemote = require("text!lib/PostMessageTransportRemote.js");
 
     EventDispatcher.makeEventDispatcher(module.exports);
-    
+
     /**
      * Saves a reference of the iframe element to a local variable
      * @param {DOM element reference to an iframe}
@@ -36,6 +36,7 @@ define(function (require, exports, module) {
     */
     function _listener(event){
         var msgObj;
+
         try {
             msgObj = JSON.parse(event.data);
         } catch (e) {
@@ -45,6 +46,9 @@ define(function (require, exports, module) {
         if(msgObj.type === "message"){
             //trigger message event
             module.exports.trigger("message", [connId, msgObj.message]);
+            if(msgObj.message.method === "CSS.setStylesheetText") {
+                reload();
+            }
         }
     }
 
@@ -123,7 +127,7 @@ define(function (require, exports, module) {
 
         launcher.launch(url);
     }
-    
+
     // Exports
     module.exports.getRemoteScript = getRemoteScript;
     module.exports.setIframe       = setIframe;

--- a/lib/PostMessageTransport.js
+++ b/lib/PostMessageTransport.js
@@ -31,6 +31,23 @@ define(function (require, exports, module) {
         }
     }
 
+    // This function maps all blob urls in a message to filesystem
+    // paths based on the urls that are cached, so that Brackets can work
+    // with paths vs. urls
+    // For e.g. a message like `{"stylesheets": {"blob://http://url" :
+    // ["blob://http://url"]}}` will be mapped into `{"stylesheets":
+    // {"/file1" : ["/file1"]}}`
+    function resolveLinks(message) {
+        var regex = new RegExp('\\"(blob:[^"]+)\\"', 'gm');
+        var resolvedMessage = message.replace(regex, function(match, url) {
+            var path = BlobUtils.getFilename(url);
+
+            return ["\"", path, "\""].join("");
+        });
+
+        return resolvedMessage;
+    }
+
     /**
     * Message event listener
     */
@@ -44,11 +61,12 @@ define(function (require, exports, module) {
         }
 
         if(msgObj.type === "message"){
+            if(msgObj.message) {
+                msgObj.message = resolveLinks(msgObj.message);
+            }
+
             //trigger message event
             module.exports.trigger("message", [connId, msgObj.message]);
-            if(msgObj.message.method === "CSS.setStylesheetText") {
-                reload();
-            }
         }
     }
 
@@ -62,7 +80,7 @@ define(function (require, exports, module) {
     /**
     * Replaces paths of linked files with blob urls
     */
-    function resolveLinks(message) {
+    function resolvePaths(message) {
         var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
         if(!currentDoc) {
             return message;
@@ -97,7 +115,7 @@ define(function (require, exports, module) {
         }
 
         if(msg && msg.params && msg.params.expression) {
-            msg.params.expression = resolveLinks(msg.params.expression);
+            msg.params.expression = resolvePaths(msg.params.expression);
         }
 
         win.postMessage(JSON.stringify(msg), "*");

--- a/lib/PostMessageTransportRemote.js
+++ b/lib/PostMessageTransportRemote.js
@@ -14,14 +14,31 @@
          * @type {?{connect: ?function, message: ?function(string), close: ?function}}
          */
         _callbacks: null,
-        
+
         /**
-         * Sets the callbacks that should be called when various transport events occur. 
+         * Sets the callbacks that should be called when various transport events occur.
          */
         setCallbacks: function (callbacks) {
             this._callbacks = callbacks;
         },
-        
+
+        /**
+         * Connects to the NodeSocketTransport in Brackets at the given WebSocket URL.
+         * @param {string} url
+         */
+        connect: function (url) {
+            var self = this;
+
+            parent.postMessage(JSON.stringify({
+                type: "connect",
+                url: global.location.href
+            }), "*");
+
+            if (self._callbacks && self._callbacks.connect) {
+                self._callbacks.connect();
+            }
+        },
+
         /**
          * Sends a message over the transport.
          * @param {string} msgStr The message to send.
@@ -32,13 +49,14 @@
                 message: msgStr
             }), "*");
         },
-        
-        /** 
+
+        /**
          * Establish postMessage connection.
          */
         enable: function () {
+            this.connect();
             var self = this;
-            
+
             // Listen for message.
             window.addEventListener("message", function (event) {
                 if (self._callbacks && self._callbacks.message) {
@@ -47,6 +65,6 @@
             });
         }
     };
-    
+
     global._Brackets_LiveDev_Transport = postMessageTransport;
 }(this));

--- a/lib/PostMessageTransportRemote.js
+++ b/lib/PostMessageTransportRemote.js
@@ -22,10 +22,6 @@
             this._callbacks = callbacks;
         },
 
-        /**
-         * Connects to the NodeSocketTransport in Brackets at the given WebSocket URL.
-         * @param {string} url
-         */
         connect: function (url) {
             var self = this;
 


### PR DESCRIPTION
This patch does a couple of things:
- Allows bbld to capture the connection messages sent by brackets to trigger a reload
- Change the way messages are sent from the iframe to brackets by converting blob urls to paths
- Adds support to caching blob urls in a synchronous manner
