### PR TITLE
Don't send reload messages over transport

### DIFF
--- a/lib/PostMessageTransport.js
+++ b/lib/PostMessageTransport.js
@@ -84,17 +84,19 @@ define(function (require, exports, module) {
         var win = _iframeRef.contentWindow;
         var msg = JSON.parse(msgStr);
 
+        // Because we need to deal with reloads on this side (i.e., editor) of the
+        // transport, check message before sending to remote, and reload if necessary
+        // without actually sending to remote for processing.
+        if(msg.method === "Page.reload" || msg.method === "Page.navigate") {
+            reload();
+            return;
+        }
+
         if(msg && msg.params && msg.params.expression) {
             msg.params.expression = resolveLinks(msg.params.expression);
         }
 
-        msgStr = JSON.stringify(msg);
-
-        win.postMessage(msgStr,"*");
-
-        if(msg.method === "Page.reload" || msg.method === "Page.navigate") {
-            reload();
-        }
+        win.postMessage(JSON.stringify(msg), "*");
     }
 
     /**


### PR DESCRIPTION
We had a bug in our reload intercept code, such that we ended up doing the reload twice (i.e., we called reload() _and_ also sent the message over the transport).  We shouldn't send reload messages at all, and should just process them on the editor side of the transport.
