### PR TITLE
Fix humphd/brackets#125 - Figure out why Quick Edit refuses to disappear

### DIFF
--- a/lib/default-files/script.js
+++ b/lib/default-files/script.js
@@ -1,0 +1,8 @@
+/**
+ * This is a basic JavaScript file.  You can include
+ * and use it in your web page by adding the following:
+ * <script src="script.js"></script>
+ */
+function add(a, b) {
+  return a + b;
+}

--- a/lib/default-files/style.css
+++ b/lib/default-files/style.css
@@ -1,0 +1,8 @@
+/**
+ * This is a basic CSS file.  You can include and use it in
+ * your web page by adding the following inside the <head>:
+ * <link href="style.css" rel="stylesheet" type="text/css">
+ */
+p {
+  color: purple;
+}

--- a/main.js
+++ b/main.js
@@ -41,6 +41,8 @@ define(function (require, exports, module) {
 
     // Load initial document
     var defaultHTML = brackets.getModule("text!filesystem/impls/filer/lib/default.html");
+    var defaultCSS  = require("text!lib/default-files/style.css");
+    var defaultJS   = require("text!lib/default-files/script.js");
 
     // Force entry to if statments on line 262 of brackets.js to create
     // a new project
@@ -295,9 +297,12 @@ define(function (require, exports, module) {
 
             window.addEventListener("message", _buttonListener);
 
-            var file = FileSystem.getFileForPath("/index.html");
+            var fileHTML = FileSystem.getFileForPath("/index.html");
+            var fileCSS  = FileSystem.getFileForPath("/style.css");
+            var fileJS   = FileSystem.getFileForPath("/script.js");
 
-            file.write(data.source ? data.source : defaultHTML,
+            // Write the HTML file and block on it being done.
+            fileHTML.write(data.source ? data.source : defaultHTML,
                 function(err) {
                     if (err) {
                         deferred.reject();
@@ -307,6 +312,20 @@ define(function (require, exports, module) {
                     deferred.resolve();
                 }
             );
+
+            // Write the CSS and JS file without blocking.
+            fileCSS.write(defaultCSS, function(err) {
+                if (err) {
+                    console.error("Couldn't write /style.css");
+                    return;
+                }
+
+                fileJS.write(defaultJS, function(err) {
+                    if (err) {
+                        console.error("Couldn't write /script.js");
+                    }
+                });
+            });
         }
 
         window.addEventListener("message", _getInitialDocument);


### PR DESCRIPTION
Fixes https://github.com/humphd/brackets/issues/125. This patch creates an empty `style.css` file when brackets is loaded. This issue occurs because there are no `.css`, `.less`, or `.scss` files in the file tree. If you remove all `.css`, `.less`, or `.scss` files from desktop brackets the same issue we have will replicate.
