### PR TITLE
fixes humphd/brackets#226 - adds support for protocol-less URLs

### DIFF
--- a/lib/PostMessageTransport.js
+++ b/lib/PostMessageTransport.js
@@ -135,10 +135,12 @@ define(function (require, exports, module) {
 
     /**
      * Returns the script that should be injected into the browser to handle the other end of the transport.
+     * Includes a base tag to handle external protocol-less, linked files.
      * @return {string}
      */
     function getRemoteScript() {
-        return "<script>\n" +
+        return '<base href="' + window.location.href + '">\n' +
+            "<script>\n" +
             PostMessageTransportRemote +
             "</script>\n";
     }


### PR DESCRIPTION
Patch adds support for external protocol-less, linked files. Added a base tag as part of the remote scripts injected into the live preview.
