### PR TITLE
Fixes humphd/brackets#228 - Gives editor focus on second pane click

### DIFF
--- a/lib/UI.js
+++ b/lib/UI.js
@@ -4,11 +4,12 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var Menus       = brackets.getModule("command/Menus"),
-        Resizer     = brackets.getModule("utils/Resizer"),
-        UrlParams   = brackets.getModule("utils/UrlParams").UrlParams,
-        StatusBar   = brackets.getModule("widgets/StatusBar"),
-        Strings     = brackets.getModule("strings");
+    var Menus               = brackets.getModule("command/Menus"),
+        Resizer             = brackets.getModule("utils/Resizer"),
+        UrlParams           = brackets.getModule("utils/UrlParams").UrlParams,
+        StatusBar           = brackets.getModule("widgets/StatusBar"),
+        Strings             = brackets.getModule("strings"),
+        MainViewManager     = brackets.getModule("view/MainViewManager");
 
     var PhonePreview  = require("text!lib/Mobile.html");
     var PostMessageTransport = require("lib/PostMessageTransport");
@@ -140,6 +141,11 @@ define(function (require, exports, module) {
                 showMobile();
 
                 isMobileViewOpen = true;
+                // Give focus back to the editor when the outside of the mobile phone is clicked.
+                // Prevents the status bar from disappearing.
+                $("#second-pane").click(function() {
+                    MainViewManager.setActivePaneId("first-pane");
+                });
             }
             else {
                 // Switch the icon


### PR DESCRIPTION
When the mobile view is present, clicking on the outside of the mobile phone will give the editor back focus and ultimately prevent the status bar from disappearing.
