### PR TITLE
Fix humphd/brackets#258 - Regex for path resolution incorrectly matches wrong string portions

### DIFF
--- a/lib/PostMessageTransport.js
+++ b/lib/PostMessageTransport.js
@@ -85,6 +85,15 @@ define(function (require, exports, module) {
 
     /**
     * Replaces paths of linked files with blob urls
+    * @param {string} message - Contains a message passed by the editor
+    *     to the LiveDev preview. Some examples of these messages are:
+    *     "{"method":"Runtime.evaluate","params":{"expression":"_LD.highlightRule(\"[data-brackets-id='6']\")"},"id":3}"
+    *     "{"method":"Runtime.evaluate","params":{"expression":"_LD.applyDOMEdits([{\"type\":\"attrChange\",\"tagID\":13,\"attribute\":\"href\",\"value\":\"script.js\"}])"},"id":14}"
+    *     "{"method":"CSS.setStylesheetText","params":{"url":"/style.css","text":"/**\n * This is a basic CSS file.  You can include and use it in\n * your web page by adding the following inside the <head>:\n * <link href=\"style.css\" rel=\"stylesheet\" type=\"text/css\">\n * /\np {\n  color: purpl;\n}\n"},"id":28}"
+    *     As can be noted in the second and third examples, there are cases
+    *     when a \ and/or " may or may not be present before the substring
+    *     that needs to be replaced
+    *
     */
     function resolvePaths(message) {
         var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
@@ -93,7 +102,7 @@ define(function (require, exports, module) {
         }
 
         var currentDir = Path.dirname(currentDoc.doc.file.fullPath);
-        var linkRegex = new RegExp('(\\\\?\\"?)(href|src|url)(\\\\?\\"?\\s?:?\\s?\\(?\\\\?\\"?)([^\\\\"\\)]+)(\\\\?\\"?)', 'gm');
+        var linkRegex = new RegExp('(\\\\?\\"?)(href|src|url|value)(\\\\?\\"?\\s?:?\\s?\\(?\\\\?\\"?)([^\\\\"\\),]+)(\\\\?\\"?)', 'gm');
         var resolvedMessage = message.replace(linkRegex, function(match, quote1, attr, seperator, path, quote2) {
             path = BlobUtils.getUrl(path.charAt(0) === "/" ? path : Path.join(currentDir, path));
 


### PR DESCRIPTION
Caused images to not refresh (in [#258](https://github.com/humphd/brackets/issues/258)) due to a parse error because the regex matched a part of the string that should not be resolved and added a trailing slash.
