### PR TITLE
IE won't allow Blob URLs with type text/html, use document.write() for IE.

### DIFF
--- a/lib/compatibility.js
+++ b/lib/compatibility.js
@@ -1,0 +1,59 @@
+/*jslint vars: true, plusplus: true, devel: true, nomen: true, indent: 4,
+maxerr: 50, browser: true */
+/*global define, URL */
+
+/**
+ * Not all browsers support everything we need for the live preview (I'm
+ * looking at you, IE).  This code tests features we need, and provides
+ * different strategies to solve those issues.
+ */
+define(function (require, exports, module) {
+    "use strict";
+
+    /*
+     * Try to create a Blob URL with type text/html and put in an iframe.
+     * IE won't allow it, so we have to use document.write().  The callback
+     * returns true if Blob URLs of type text/html are supported.
+     */
+    var _supportsIFrameHTMLBlobURL;
+
+    exports.supportsIFrameHTMLBlobURL = function(callback) {
+        if(typeof _supportsIFrameHTMLBlobURL !== "undefined") {
+            callback(null, _supportsIFrameHTMLBlobURL);
+            return;
+        }
+
+        var blob = new Blob(["<div id='bloburl-test'></div>"], {type: "text/html"});
+        var blobURL = URL.createObjectURL(blob);
+
+        var iframe = document.createElement("iframe");
+        iframe.style.display = "none";
+        document.body.appendChild(iframe);
+
+        var onloadTimer;
+
+        function onload() {
+            clearTimeout(onloadTimer);
+
+            // If the iframe doesn't have the expected content, it didn't load properly
+            try {
+                _supportsIFrameHTMLBlobURL = !!(iframe.contentWindow.document.querySelector("#bloburl-test"));
+                document.body.removeChild(iframe);
+                iframe = null;
+                URL.revokeObjectURL(blob);
+                blob = null;
+                blobURL = null;
+            } catch(e) {
+                _supportsIFrameHTMLBlobURL = false;
+            }
+
+            callback(null, _supportsIFrameHTMLBlobURL);
+        }
+
+        iframe.onload = onload;
+        iframe.src = blobURL;
+
+        // Just in case a browser doesn't fire onload for the iframe
+        onloadTimer = setTimeout(onload, 1000);
+    };
+});

--- a/lib/iframe-browser.js
+++ b/lib/iframe-browser.js
@@ -17,6 +17,7 @@ define(function (require, exports, module) {
     var detachedWindow;
     var isReload;
     var PostMessageTransport = require("lib/PostMessageTransport");
+    var Compatibility = require("lib/compatibility");
 
     /*
      * Publicly avaialble function used to create an empty iframe within the second-panel
@@ -80,21 +81,37 @@ define(function (require, exports, module) {
      * Function used to interact with the second-pane,
      * In which our iFrame will exists, and the detached
      * preview, if it exist. They will be filled
-     * with the url that has been passed to this function
+     * with the url (or raw HTML) that has been passed to this function
      */
-    function update(url) {
-        if(!url) {
+    function update(urlOrHTML) {
+        if(!urlOrHTML) {
             return;
         }
 
         var iframe = getBrowserIframe();
         if(iframe) {
-            iframe.src = url;
+            Compatibility.supportsIFrameHTMLBlobURL(function(err, shouldUseBlobURL) {
+                if(err) {
+                    console.error("[Brackets IFrame-Browser] Unexpected error:", err);
+                    return;
+                }
+
+                if(shouldUseBlobURL) {
+                    iframe.src = urlOrHTML;
+                } else {
+                    var doc = iframe.contentWindow.document.open("text/html", "replace");
+                    doc.write(urlOrHTML);
+                    doc.close();
+                }
+            });
         }
+
+        // TODO: this needs to be made to work with document.write()...
+        // https://github.com/humphd/brackets/issues/233
         var detachedPreview = getDetachedPreview();
         if(detachedPreview) {
             isReload = true;
-            detachedPreview.location.replace(url);
+            detachedPreview.location.replace(urlOrHTML);
         }
     }
 


### PR DESCRIPTION
This is a partial fix for IE, and gets the live dev preview working.  It has limitations, and also needs follow-up:
- links to other HTML docs won't currently work, since you can't use Blob URLs for them.  We could add a top-level click handler to the document's body, and try to sort out when a user clicked a link with a path into the filesystem, and use `postMessage` to point the preview at that HTML document instead.  This is an edge case.
- CSS, JS, etc files all seem to work.  I notice some `Access Denied` errors when running scripts, which spam the console but don't seem to prevent things from running.  I haven' tested an image yet, but I think it will be fine.
- The mobile preview is buggy.  It seems to need a reload to show content.  Flipping back and forth between desktop/mobile view often leaves the preview blank.
- The detachable preview is totally broken (it was already).  We really need to do a rewrite of that code to use what I've done here in a more logical way.
